### PR TITLE
Maj données NO v2 [NGC-654]

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -1,0 +1,7 @@
+import { copyFileSync } from 'fs'
+
+const srcPath = 'publicodes-negaoctet.model.json'
+const destPath = `./doc/src/${srcPath}`
+
+copyFileSync(srcPath, destPath)
+console.log(`✅ ${destPath} correctly written in "doc/src"`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incubateur-ademe/publicodes-negaoctet",
-  "version": "1.1.1",
+  "version": "1.2.0-rc.1",
   "description": "Modèle Publicodes de la base de données NegaOctet",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "clean": "rm -r publicodes-negaoctet.model.json index.d.ts index.js",
     "build": "node build.js",
+    "build:watch": "nodemon -e \"publicodes\" --watch rules/ build.js & nodemon --watch publicodes-negaoctet.model.json copy.js",
     "doc": "yarn run build && cp publicodes-negaoctet.model.json doc/src && cd doc && yarn run start",
     "doc:build": "yarn run build && cp publicodes-negaoctet.model.json doc/src && cd doc && yarn run build",
     "format": "prettier . --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incubateur-ademe/publicodes-negaoctet",
-  "version": "1.2.0-rc.2",
+  "version": "1.2.0",
   "description": "Modèle Publicodes de la base de données NegaOctet",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incubateur-ademe/publicodes-negaoctet",
-  "version": "1.2.0-rc.1",
+  "version": "1.2.0-rc.2",
   "description": "Modèle Publicodes de la base de données NegaOctet",
   "type": "module",
   "main": "index.js",

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -1,20 +1,4 @@
 acv:
-acv . TV:
-acv . TV . fabrication:
-  formule: 372600
-  unité: gCO2e
-acv . TV . distribution:
-  formule: 3200
-  unité: gCO2e
-acv . TV . usage théorique:
-  formule: 92700
-  unité: gCO2e
-acv . TV . fin de vie:
-  formule: 11800
-  unité: gCO2e
-acv . TV . durée de vie théorique:
-  formule: 8
-  unité: an
 
 acv . smartphone:
 acv . smartphone . fabrication:
@@ -32,6 +16,12 @@ acv . smartphone . fin de vie:
 acv . smartphone . durée de vie théorique:
   formule: 2.5
   unité: an
+acv . smartphone . consommation en mode actif:
+  formule: 5.6
+  unité: Wh
+acv . smartphone . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
 
 acv . tablette:
 acv . tablette . fabrication:
@@ -49,6 +39,12 @@ acv . tablette . fin de vie:
 acv . tablette . durée de vie théorique:
   formule: 3
   unité: an
+acv . tablette . consommation en mode actif:
+  formule: 15
+  unité: Wh
+acv . tablette . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
 
 acv . ordinateur portable:
 acv . ordinateur portable . fabrication:
@@ -66,6 +62,35 @@ acv . ordinateur portable . fin de vie:
 acv . ordinateur portable . durée de vie théorique:
   formule: 5
   unité: an
+acv . ordinateur portable . consommation en mode actif:
+  formule: 25
+  unité: Wh
+acv . ordinateur portable . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
+
+acv . TV:
+acv . TV . fabrication:
+  formule: 372600
+  unité: gCO2e
+acv . TV . distribution:
+  formule: 3200
+  unité: gCO2e
+acv . TV . usage théorique:
+  formule: 92700
+  unité: gCO2e
+acv . TV . fin de vie:
+  formule: 11800
+  unité: gCO2e
+acv . TV . durée de vie théorique:
+  formule: 8
+  unité: an
+acv . TV . consommation en mode actif:
+  formule: 65
+  unité: Wh
+acv . TV . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
 
 acv . ordinateur fixe:
 acv . ordinateur fixe . fabrication:
@@ -83,6 +108,12 @@ acv . ordinateur fixe . fin de vie:
 acv . ordinateur fixe . durée de vie théorique:
   formule: 6
   unité: an
+acv . ordinateur fixe . consommation en mode actif:
+  formule: 50
+  unité: Wh
+acv . ordinateur fixe . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
 
 acv . écran:
 acv . écran . fabrication:
@@ -100,3 +131,9 @@ acv . écran . fin de vie:
 acv . écran . durée de vie théorique:
   formule: 6
   unité: an
+acv . écran . consommation en mode actif:
+  formule: 30
+  unité: Wh
+acv . écran . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -6,21 +6,33 @@ acv:
 acv . smartphone:
   description: |
     6,63 inches screen mix of LCD and OLED technologies, 8 GB RAM, 210 GB memory (mix pondéré entre 3 configurations, 24%,24%, 52%)
-acv . smartphone . fabrication:
+acv . smartphone . carbone:
+acv . smartphone . eau:
+
+acv . smartphone . carbone . fabrication:
   formule: 83000
   unité: gCO2e
-acv . smartphone . distribution:
+acv . smartphone . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . smartphone . carbone . distribution:
   formule: 2100
   unité: gCO2e
-acv . smartphone . usage julia:
+acv . smartphone . eau . distribution:
+  formule: 1000
+  unité: l
+acv . smartphone . carbone . usage julia:
   formule: 600
   unité: gCO2e
-acv . smartphone . usage théorique:
+acv . smartphone . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . smartphone . fin de vie:
+acv . smartphone . carbone . fin de vie:
   formule: 200
   unité: gCO2e
+acv . smartphone . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . smartphone . durée de vie théorique:
   formule: 2.5
   unité: an
@@ -37,21 +49,33 @@ acv . smartphone . consommation annuelle:
 acv . tablette:
   description: |
     10.53 inches screen mix of LCD screen, 4.7 GB RAM, 144 GB memory (mix pondéré entre 3 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 42)
-acv . tablette . fabrication:
+acv . tablette . carbone:
+acv . tablette . eau:
+
+acv . tablette . carbone . fabrication:
   formule: 56300
   unité: gCO2e
-acv . tablette . distribution:
+acv . tablette . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . tablette . carbone . distribution:
   formule: 3400
   unité: gCO2e
-acv . tablette . usage julia:
+acv . tablette . eau . distribution:
+  formule: 1000
+  unité: l
+acv . tablette . carbone . usage julia:
   formule: 3200
   unité: gCO2e
-acv . tablette . usage théorique:
+acv . tablette . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . tablette . fin de vie:
+acv . tablette . carbone . fin de vie:
   formule: 400
   unité: gCO2e
+acv . tablette . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . tablette . durée de vie théorique:
   formule: 3
   unité: an
@@ -68,21 +92,33 @@ acv . tablette . consommation annuelle:
 acv . ordinateur portable:
   description: |
     14,6 inches screen, 1 CPU, 11 GB RAM, 497 GB SSD (mix pondéré entre 3 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 43-44)
-acv . ordinateur portable . fabrication:
+acv . ordinateur portable . carbone:
+acv . ordinateur portable . eau:
+
+acv . ordinateur portable . carbone . fabrication:
   formule: 170300
   unité: gCO2e
-acv . ordinateur portable . distribution:
+acv . ordinateur portable . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . ordinateur portable . carbone . distribution:
   formule: 12300
   unité: gCO2e
-acv . ordinateur portable . usage julia:
+acv . ordinateur portable . eau . distribution:
+  formule: 1000
+  unité: l
+acv . ordinateur portable . carbone . usage julia:
   formule: 8300
   unité: gCO2e
-acv . ordinateur portable . usage théorique:
+acv . ordinateur portable . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . ordinateur portable . fin de vie:
+acv . ordinateur portable . carbone . fin de vie:
   formule: 2800
   unité: gCO2e
+acv . ordinateur portable . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . ordinateur portable . durée de vie théorique:
   formule: 5
   unité: an
@@ -99,21 +135,33 @@ acv . ordinateur portable . consommation annuelle:
 acv . TV:
   description: |
     Average dimension and technology (82% LCD (45 inches), 1% OLED (53 inches), 17% OLED (68 inches)) (mix pondéré entre 3 configurations)
-acv . TV . fabrication:
+acv . TV . carbone:
+acv . TV . eau:
+
+acv . TV . carbone . fabrication:
   formule: 372600
   unité: gCO2e
-acv . TV . distribution:
+acv . TV . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . TV . carbone . distribution:
   formule: 3200
   unité: gCO2e
-acv . TV . usage julia:
+acv . TV . eau . distribution:
+  formule: 1000
+  unité: l
+acv . TV . carbone . usage julia:
   formule: 92700
   unité: gCO2e
-acv . TV . usage théorique:
+acv . TV . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . TV . fin de vie:
+acv . TV . carbone . fin de vie:
   formule: 11800
   unité: gCO2e
+acv . TV . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . TV . durée de vie théorique:
   formule: 8
   unité: an
@@ -130,21 +178,33 @@ acv . TV . consommation annuelle:
 acv . ordinateur fixe:
   description: |
     1 CPU, 10 GB RAM, 1173 GB HDD, 442 GB SSD, mix of integrated or separated graphic card  (mix pondéré entre 5 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 45)
-acv . ordinateur fixe . fabrication:
+acv . ordinateur fixe . carbone:
+acv . ordinateur fixe . eau:
+
+acv . ordinateur fixe . carbone . fabrication:
   formule: 258600
   unité: gCO2e
-acv . ordinateur fixe . distribution:
+acv . ordinateur fixe . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . ordinateur fixe . carbone . distribution:
   formule: 2900
   unité: gCO2e
-acv . ordinateur fixe . usage julia:
+acv . ordinateur fixe . eau . distribution:
+  formule: 1000
+  unité: l
+acv . ordinateur fixe . carbone . usage julia:
   formule: 34100
   unité: gCO2e
-acv . ordinateur fixe . usage théorique:
+acv . ordinateur fixe . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . ordinateur fixe . fin de vie:
+acv . ordinateur fixe . carbone . fin de vie:
   formule: 6600
   unité: gCO2e
+acv . ordinateur fixe . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . ordinateur fixe . durée de vie théorique:
   formule: 6
   unité: an
@@ -161,21 +221,33 @@ acv . ordinateur fixe . consommation annuelle:
 acv . écran:
   description: |
     Dimension moyenne (24 inches) et mix de technologie (98.6% LCD, 1.4% OLED)  (mix pondéré entre 2 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 49)
-acv . écran . fabrication:
+acv . écran . carbone:
+acv . écran . eau:
+
+acv . écran . carbone . fabrication:
   formule: 64600
   unité: gCO2e
-acv . écran . distribution:
+acv . écran . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . écran . carbone . distribution:
   formule: 1300
   unité: gCO2e
-acv . écran . usage julia:
+acv . écran . eau . distribution:
+  formule: 1000
+  unité: l
+acv . écran . carbone . usage julia:
   formule: 23900
   unité: gCO2e
-acv . écran . usage théorique:
+acv . écran . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . écran . fin de vie:
+acv . écran . carbone . fin de vie:
   formule: 3900
   unité: gCO2e
+acv . écran . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . écran . durée de vie théorique:
   formule: 6
   unité: an
@@ -193,18 +265,30 @@ acv . casque:
   titre: Casque de réalité virtuelle
   description: |
     Moyenne de deux technologies (50% LCD, 50%OLED) + prise en compte de deux manettes
-acv . casque . fabrication:
+acv . casque . carbone:
+acv . casque . eau:
+
+acv . casque . carbone . fabrication:
   formule: 70400
   unité: gCO2e
-acv . casque . distribution:
+acv . casque . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . casque . carbone . distribution:
   formule: 400
   unité: gCO2e
-acv . casque . usage théorique:
+acv . casque . eau . distribution:
+  formule: 1000
+  unité: l
+acv . casque . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . casque . fin de vie:
+acv . casque . carbone . fin de vie:
   formule: 1300
   unité: gCO2e
+acv . casque . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . casque . durée de vie théorique:
   formule: 5
   unité: an
@@ -220,19 +304,31 @@ acv . casque . consommation annuelle:
 
 acv . enceinte:
   titre: Enceinte connectée
-acv . enceinte . fabrication:
+acv . enceinte . carbone:
+acv . enceinte . eau:
+
+acv . enceinte . carbone . fabrication:
   formule: 19500
   unité: gCO2e
-acv . enceinte . distribution:
+acv . enceinte . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . enceinte . carbone . distribution:
   formule: 300
   unité: gCO2e
-acv . enceinte . usage théorique:
+acv . enceinte . eau . distribution:
+  formule: 1000
+  unité: l
+acv . enceinte . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . enceinte . fin de vie:
+acv . enceinte . carbone . fin de vie:
   formule: 700
   unité: gCO2e
-acv . enceinte . durée de vie théorique:
+acv . enceinte . eau . fin de vie:
+  formule: 1000
+  unité: l
+acv . enceinte . carbone . durée de vie théorique:
   formule: 5
   unité: an
 acv . enceinte . consommation en mode actif:
@@ -246,18 +342,30 @@ acv . enceinte . consommation annuelle:
   unité: kWh
 
 acv . console de salon:
-acv . console de salon . fabrication:
+acv . console de salon . carbone:
+acv . console de salon . eau:
+
+acv . console de salon . carbone . fabrication:
   formule: 279000
   unité: gCO2e
-acv . console de salon . distribution:
+acv . console de salon . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . console de salon . carbone . distribution:
   formule: 1200
   unité: gCO2e
-acv . console de salon . usage théorique:
+acv . console de salon . eau . distribution:
+  formule: 1000
+  unité: l
+acv . console de salon . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . console de salon . fin de vie:
+acv . console de salon . carbone . fin de vie:
   formule: 4600
   unité: gCO2e
+acv . console de salon . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . console de salon . durée de vie théorique:
   formule: 6
   unité: an
@@ -272,19 +380,30 @@ acv . console de salon . consommation annuelle:
   unité: kWh
 
 acv . console portable:
-  titre: Enceinte connectée
-acv . console portable . fabrication:
+acv . console portable . carbone:
+acv . console portable . eau:
+
+acv . console portable . carbone . fabrication:
   formule: 64800
   unité: gCO2e
-acv . console portable . distribution:
+acv . console portable . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . console portable . carbone . distribution:
   formule: 300
   unité: gCO2e
-acv . console portable . usage théorique:
+acv . console portable . eau . distribution:
+  formule: 1000
+  unité: l
+acv . console portable . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . console portable . fin de vie:
+acv . console portable . carbone . fin de vie:
   formule: 500
   unité: gCO2e
+acv . console portable . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . console portable . durée de vie théorique:
   formule: 6
   unité: an
@@ -299,18 +418,30 @@ acv . console portable . consommation annuelle:
   unité: kWh
 
 acv . imprimante:
-acv . imprimante . fabrication:
+acv . imprimante . carbone:
+acv . imprimante . eau:
+
+acv . imprimante . carbone . fabrication:
   formule: 10500
   unité: gCO2e
-acv . imprimante . distribution:
+acv . imprimante . eau . fabrication:
+  formule: 1000
+  unité: l
+acv . imprimante . carbone . distribution:
   formule: 300
   unité: gCO2e
-acv . imprimante . usage théorique:
+acv . imprimante . eau . distribution:
+  formule: 1000
+  unité: l
+acv . imprimante . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
-acv . imprimante . fin de vie:
+acv . imprimante . carbone . fin de vie:
   formule: 10200
   unité: gCO2e
+acv . imprimante . eau . fin de vie:
+  formule: 1000
+  unité: l
 acv . imprimante . durée de vie théorique:
   formule: 5
   unité: an

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -1,6 +1,11 @@
 acv:
+  titre: Analyse de cycle de vie des appareils
+  description: |
+    Cette section présente les émissions de gaz à effet de serre liées à la fabrication, la distribution, l'usage et la fin de vie des appareils électroniques selon l'étude menée par Negaoctet.
 
 acv . smartphone:
+  description: |
+    6,63 inches screen mix of LCD and OLED technologies, 8 GB RAM, 210 GB memory (mix pondéré entre 3 configurations, 24%,24%, 52%)
 acv . smartphone . fabrication:
   formule: 83000
   unité: gCO2e
@@ -30,6 +35,8 @@ acv . smartphone . consommation annuelle:
   unité: kWh
 
 acv . tablette:
+  description: |
+    10.53 inches screen mix of LCD screen, 4.7 GB RAM, 144 GB memory (mix pondéré entre 3 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 42)
 acv . tablette . fabrication:
   formule: 56300
   unité: gCO2e
@@ -59,6 +66,8 @@ acv . tablette . consommation annuelle:
   unité: kWh
 
 acv . ordinateur portable:
+  description: |
+    14,6 inches screen, 1 CPU, 11 GB RAM, 497 GB SSD (mix pondéré entre 3 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 43-44)
 acv . ordinateur portable . fabrication:
   formule: 170300
   unité: gCO2e
@@ -88,6 +97,8 @@ acv . ordinateur portable . consommation annuelle:
   unité: kWh
 
 acv . TV:
+  description: |
+    Average dimension and technology (82% LCD (45 inches), 1% OLED (53 inches), 17% OLED (68 inches)) (mix pondéré entre 3 configurations)
 acv . TV . fabrication:
   formule: 372600
   unité: gCO2e
@@ -117,6 +128,8 @@ acv . TV . consommation annuelle:
   unité: kWh
 
 acv . ordinateur fixe:
+  description: |
+    1 CPU, 10 GB RAM, 1173 GB HDD, 442 GB SSD, mix of integrated or separated graphic card  (mix pondéré entre 5 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 45)
 acv . ordinateur fixe . fabrication:
   formule: 258600
   unité: gCO2e
@@ -146,6 +159,8 @@ acv . ordinateur fixe . consommation annuelle:
   unité: kWh
 
 acv . écran:
+  description: |
+    Dimension moyenne (24 inches) et mix de technologie (98.6% LCD, 1.4% OLED)  (mix pondéré entre 2 configurations, étude [ADEME-ARCEP](https://librairie.ademe.fr/consommer-autrement/5226-evaluation-de-l-impact-environnemental-du-numerique-en-france-et-analyse-prospective.html), Rapport 2, page 49)
 acv . écran . fabrication:
   formule: 64600
   unité: gCO2e

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -13,13 +13,13 @@ acv . smartphone . carbone . fabrication:
   formule: 83000
   unité: gCO2e
 acv . smartphone . eau . fabrication:
-  formule: 1000
+  formule: 76000
   unité: l
 acv . smartphone . carbone . distribution:
   formule: 2100
   unité: gCO2e
 acv . smartphone . eau . distribution:
-  formule: 1000
+  formule: 10
   unité: l
 acv . smartphone . carbone . usage julia:
   formule: 600
@@ -31,7 +31,7 @@ acv . smartphone . carbone . fin de vie:
   formule: 200
   unité: gCO2e
 acv . smartphone . eau . fin de vie:
-  formule: 1000
+  formule: 58300
   unité: l
 acv . smartphone . durée de vie théorique:
   formule: 2.5
@@ -56,13 +56,13 @@ acv . tablette . carbone . fabrication:
   formule: 56300
   unité: gCO2e
 acv . tablette . eau . fabrication:
-  formule: 1000
+  formule: 98500
   unité: l
 acv . tablette . carbone . distribution:
   formule: 3400
   unité: gCO2e
 acv . tablette . eau . distribution:
-  formule: 1000
+  formule: 20
   unité: l
 acv . tablette . carbone . usage julia:
   formule: 3200
@@ -74,7 +74,7 @@ acv . tablette . carbone . fin de vie:
   formule: 400
   unité: gCO2e
 acv . tablette . eau . fin de vie:
-  formule: 1000
+  formule: 61500
   unité: l
 acv . tablette . durée de vie théorique:
   formule: 3
@@ -99,13 +99,13 @@ acv . ordinateur portable . carbone . fabrication:
   formule: 170300
   unité: gCO2e
 acv . ordinateur portable . eau . fabrication:
-  formule: 1000
+  formule: 194200
   unité: l
 acv . ordinateur portable . carbone . distribution:
   formule: 12300
   unité: gCO2e
 acv . ordinateur portable . eau . distribution:
-  formule: 1000
+  formule: 60
   unité: l
 acv . ordinateur portable . carbone . usage julia:
   formule: 8300
@@ -117,7 +117,7 @@ acv . ordinateur portable . carbone . fin de vie:
   formule: 2800
   unité: gCO2e
 acv . ordinateur portable . eau . fin de vie:
-  formule: 1000
+  formule: 638400
   unité: l
 acv . ordinateur portable . durée de vie théorique:
   formule: 5
@@ -142,13 +142,13 @@ acv . TV . carbone . fabrication:
   formule: 372600
   unité: gCO2e
 acv . TV . eau . fabrication:
-  formule: 1000
+  formule: 1113200
   unité: l
 acv . TV . carbone . distribution:
   formule: 3200
   unité: gCO2e
 acv . TV . eau . distribution:
-  formule: 1000
+  formule: 10
   unité: l
 acv . TV . carbone . usage julia:
   formule: 92700
@@ -160,7 +160,7 @@ acv . TV . carbone . fin de vie:
   formule: 11800
   unité: gCO2e
 acv . TV . eau . fin de vie:
-  formule: 1000
+  formule: 1316400
   unité: l
 acv . TV . durée de vie théorique:
   formule: 8
@@ -185,13 +185,13 @@ acv . ordinateur fixe . carbone . fabrication:
   formule: 258600
   unité: gCO2e
 acv . ordinateur fixe . eau . fabrication:
-  formule: 1000
+  formule: 81900
   unité: l
 acv . ordinateur fixe . carbone . distribution:
   formule: 2900
   unité: gCO2e
 acv . ordinateur fixe . eau . distribution:
-  formule: 1000
+  formule: 10
   unité: l
 acv . ordinateur fixe . carbone . usage julia:
   formule: 34100
@@ -203,7 +203,7 @@ acv . ordinateur fixe . carbone . fin de vie:
   formule: 6600
   unité: gCO2e
 acv . ordinateur fixe . eau . fin de vie:
-  formule: 1000
+  formule: 2070000
   unité: l
 acv . ordinateur fixe . durée de vie théorique:
   formule: 6
@@ -228,13 +228,13 @@ acv . écran . carbone . fabrication:
   formule: 64600
   unité: gCO2e
 acv . écran . eau . fabrication:
-  formule: 1000
+  formule: 58300
   unité: l
 acv . écran . carbone . distribution:
   formule: 1300
   unité: gCO2e
 acv . écran . eau . distribution:
-  formule: 1000
+  formule: 5
   unité: l
 acv . écran . carbone . usage julia:
   formule: 23900
@@ -246,7 +246,7 @@ acv . écran . carbone . fin de vie:
   formule: 3900
   unité: gCO2e
 acv . écran . eau . fin de vie:
-  formule: 1000
+  formule: 677200
   unité: l
 acv . écran . durée de vie théorique:
   formule: 6
@@ -272,13 +272,13 @@ acv . casque . carbone . fabrication:
   formule: 70400
   unité: gCO2e
 acv . casque . eau . fabrication:
-  formule: 1000
+  formule: 100200
   unité: l
 acv . casque . carbone . distribution:
   formule: 400
   unité: gCO2e
 acv . casque . eau . distribution:
-  formule: 1000
+  formule: 5
   unité: l
 acv . casque . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
@@ -287,8 +287,9 @@ acv . casque . carbone . fin de vie:
   formule: 1300
   unité: gCO2e
 acv . casque . eau . fin de vie:
-  formule: 1000
+  formule: -23600
   unité: l
+  note: Curieux cette valeur négative, la seule parmi les appareils ici.
 acv . casque . durée de vie théorique:
   formule: 5
   unité: an
@@ -311,13 +312,13 @@ acv . enceinte . carbone . fabrication:
   formule: 19500
   unité: gCO2e
 acv . enceinte . eau . fabrication:
-  formule: 1000
+  formule: 4410
   unité: l
 acv . enceinte . carbone . distribution:
   formule: 300
   unité: gCO2e
 acv . enceinte . eau . distribution:
-  formule: 1000
+  formule: 5
   unité: l
 acv . enceinte . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
@@ -326,9 +327,9 @@ acv . enceinte . carbone . fin de vie:
   formule: 700
   unité: gCO2e
 acv . enceinte . eau . fin de vie:
-  formule: 1000
+  formule: 112000
   unité: l
-acv . enceinte . carbone . durée de vie théorique:
+acv . enceinte . durée de vie théorique:
   formule: 5
   unité: an
 acv . enceinte . consommation en mode actif:
@@ -349,13 +350,13 @@ acv . console de salon . carbone . fabrication:
   formule: 279000
   unité: gCO2e
 acv . console de salon . eau . fabrication:
-  formule: 1000
+  formule: 101000
   unité: l
 acv . console de salon . carbone . distribution:
   formule: 1200
   unité: gCO2e
 acv . console de salon . eau . distribution:
-  formule: 1000
+  formule: 1
   unité: l
 acv . console de salon . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
@@ -364,7 +365,7 @@ acv . console de salon . carbone . fin de vie:
   formule: 4600
   unité: gCO2e
 acv . console de salon . eau . fin de vie:
-  formule: 1000
+  formule: 907000
   unité: l
 acv . console de salon . durée de vie théorique:
   formule: 6
@@ -387,13 +388,13 @@ acv . console portable . carbone . fabrication:
   formule: 64800
   unité: gCO2e
 acv . console portable . eau . fabrication:
-  formule: 1000
+  formule: 23000
   unité: l
 acv . console portable . carbone . distribution:
   formule: 300
   unité: gCO2e
 acv . console portable . eau . distribution:
-  formule: 1000
+  formule: 1
   unité: l
 acv . console portable . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
@@ -402,7 +403,7 @@ acv . console portable . carbone . fin de vie:
   formule: 500
   unité: gCO2e
 acv . console portable . eau . fin de vie:
-  formule: 1000
+  formule: 112000
   unité: l
 acv . console portable . durée de vie théorique:
   formule: 6
@@ -425,13 +426,13 @@ acv . imprimante . carbone . fabrication:
   formule: 10500
   unité: gCO2e
 acv . imprimante . eau . fabrication:
-  formule: 1000
+  formule: 40500
   unité: l
 acv . imprimante . carbone . distribution:
   formule: 300
   unité: gCO2e
 acv . imprimante . eau . distribution:
-  formule: 1000
+  formule: 20
   unité: l
 acv . imprimante . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
@@ -440,7 +441,7 @@ acv . imprimante . carbone . fin de vie:
   formule: 10200
   unité: gCO2e
 acv . imprimante . eau . fin de vie:
-  formule: 1000
+  formule: 2400000
   unité: l
 acv . imprimante . durée de vie théorique:
   formule: 5

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -1,0 +1,102 @@
+acv:
+acv . TV:
+acv . TV . fabrication:
+  formule: 372600
+  unité: gCO2e
+acv . TV . distribution:
+  formule: 3200
+  unité: gCO2e
+acv . TV . usage théorique:
+  formule: 92700
+  unité: gCO2e
+acv . TV . fin de vie:
+  formule: 11800
+  unité: gCO2e
+acv . TV . durée de vie théorique:
+  formule: 8
+  unité: an
+
+acv . smartphone:
+acv . smartphone . fabrication:
+  formule: 83000
+  unité: gCO2e
+acv . smartphone . distribution:
+  formule: 2100
+  unité: gCO2e
+acv . smartphone . usage théorique:
+  formule: 600
+  unité: gCO2e
+acv . smartphone . fin de vie:
+  formule: 200
+  unité: gCO2e
+acv . smartphone . durée de vie théorique:
+  formule: 2.5
+  unité: an
+
+acv . tablette:
+acv . tablette . fabrication:
+  formule: 56300
+  unité: gCO2e
+acv . tablette . distribution:
+  formule: 3400
+  unité: gCO2e
+acv . tablette . usage théorique:
+  formule: 3200
+  unité: gCO2e
+acv . tablette . fin de vie:
+  formule: 400
+  unité: gCO2e
+acv . tablette . durée de vie théorique:
+  formule: 3
+  unité: an
+
+acv . ordinateur portable:
+acv . ordinateur portable . fabrication:
+  formule: 170300
+  unité: gCO2e
+acv . ordinateur portable . distribution:
+  formule: 12300
+  unité: gCO2e
+acv . ordinateur portable . usage théorique:
+  formule: 8300
+  unité: gCO2e
+acv . ordinateur portable . fin de vie:
+  formule: 2800
+  unité: gCO2e
+acv . ordinateur portable . durée de vie théorique:
+  formule: 5
+  unité: an
+
+acv . ordinateur fixe:
+acv . ordinateur fixe . fabrication:
+  formule: 258600
+  unité: gCO2e
+acv . ordinateur fixe . distribution:
+  formule: 2900
+  unité: gCO2e
+acv . ordinateur fixe . usage théorique:
+  formule: 34100
+  unité: gCO2e
+acv . ordinateur fixe . fin de vie:
+  formule: 6600
+  unité: gCO2e
+acv . ordinateur fixe . durée de vie théorique:
+  formule: 6
+  unité: an
+
+acv . écran:
+acv . écran . fabrication:
+  formule: 64600
+  unité: gCO2e
+acv . écran . distribution:
+  formule: 1300
+  unité: gCO2e
+acv . écran . usage théorique:
+  formule: 23900
+  unité: gCO2e
+acv . écran . fin de vie:
+  formule: 3900
+  unité: gCO2e
+acv . écran . durée de vie théorique:
+  formule: 6
+  unité: an

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -7,8 +7,11 @@ acv . smartphone . fabrication:
 acv . smartphone . distribution:
   formule: 2100
   unité: gCO2e
-acv . smartphone . usage théorique:
+acv . smartphone . usage julia:
   formule: 600
+  unité: gCO2e
+acv . smartphone . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . smartphone . fin de vie:
   formule: 200
@@ -21,7 +24,10 @@ acv . smartphone . consommation en mode actif:
   unité: Wh
 acv . smartphone . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
+acv . smartphone . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
 
 acv . tablette:
 acv . tablette . fabrication:
@@ -30,8 +36,11 @@ acv . tablette . fabrication:
 acv . tablette . distribution:
   formule: 3400
   unité: gCO2e
-acv . tablette . usage théorique:
+acv . tablette . usage julia:
   formule: 3200
+  unité: gCO2e
+acv . tablette . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . tablette . fin de vie:
   formule: 400
@@ -45,6 +54,9 @@ acv . tablette . consommation en mode actif:
 acv . tablette . profil utilisation théorique:
   formule: 3
   unité: heure/jour
+acv . tablette . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
 
 acv . ordinateur portable:
 acv . ordinateur portable . fabrication:
@@ -53,8 +65,11 @@ acv . ordinateur portable . fabrication:
 acv . ordinateur portable . distribution:
   formule: 12300
   unité: gCO2e
-acv . ordinateur portable . usage théorique:
+acv . ordinateur portable . usage julia:
   formule: 8300
+  unité: gCO2e
+acv . ordinateur portable . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . ordinateur portable . fin de vie:
   formule: 2800
@@ -68,6 +83,9 @@ acv . ordinateur portable . consommation en mode actif:
 acv . ordinateur portable . profil utilisation théorique:
   formule: 3
   unité: heure/jour
+acv . ordinateur portable . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
 
 acv . TV:
 acv . TV . fabrication:
@@ -76,8 +94,11 @@ acv . TV . fabrication:
 acv . TV . distribution:
   formule: 3200
   unité: gCO2e
-acv . TV . usage théorique:
+acv . TV . usage julia:
   formule: 92700
+  unité: gCO2e
+acv . TV . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . TV . fin de vie:
   formule: 11800
@@ -91,6 +112,9 @@ acv . TV . consommation en mode actif:
 acv . TV . profil utilisation théorique:
   formule: 3
   unité: heure/jour
+acv . TV . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
 
 acv . ordinateur fixe:
 acv . ordinateur fixe . fabrication:
@@ -99,8 +123,11 @@ acv . ordinateur fixe . fabrication:
 acv . ordinateur fixe . distribution:
   formule: 2900
   unité: gCO2e
-acv . ordinateur fixe . usage théorique:
+acv . ordinateur fixe . usage julia:
   formule: 34100
+  unité: gCO2e
+acv . ordinateur fixe . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . ordinateur fixe . fin de vie:
   formule: 6600
@@ -114,6 +141,9 @@ acv . ordinateur fixe . consommation en mode actif:
 acv . ordinateur fixe . profil utilisation théorique:
   formule: 3
   unité: heure/jour
+acv . ordinateur fixe . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
 
 acv . écran:
 acv . écran . fabrication:
@@ -122,8 +152,11 @@ acv . écran . fabrication:
 acv . écran . distribution:
   formule: 1300
   unité: gCO2e
-acv . écran . usage théorique:
+acv . écran . usage julia:
   formule: 23900
+  unité: gCO2e
+acv . écran . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
 acv . écran . fin de vie:
   formule: 3900
@@ -137,3 +170,6 @@ acv . écran . consommation en mode actif:
 acv . écran . profil utilisation théorique:
   formule: 3
   unité: heure/jour
+acv . écran . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -188,3 +188,138 @@ acv . écran . profil utilisation théorique:
 acv . écran . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
+
+acv . casque:
+  titre: Casque de réalité virtuelle
+  description: |
+    Moyenne de deux technologies (50% LCD, 50%OLED) + prise en compte de deux manettes
+acv . casque . fabrication:
+  formule: 70400
+  unité: gCO2e
+acv . casque . distribution:
+  formule: 400
+  unité: gCO2e
+acv . casque . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
+  unité: gCO2e
+acv . casque . fin de vie:
+  formule: 1300
+  unité: gCO2e
+acv . casque . durée de vie théorique:
+  formule: 5
+  unité: an
+acv . casque . consommation en mode actif:
+  formule: 2
+  unité: Wh
+acv . casque . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
+acv . casque . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
+
+acv . enceinte:
+  titre: Enceinte connectée
+acv . enceinte . fabrication:
+  formule: 19500
+  unité: gCO2e
+acv . enceinte . distribution:
+  formule: 300
+  unité: gCO2e
+acv . enceinte . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
+  unité: gCO2e
+acv . enceinte . fin de vie:
+  formule: 700
+  unité: gCO2e
+acv . enceinte . durée de vie théorique:
+  formule: 5
+  unité: an
+acv . enceinte . consommation en mode actif:
+  formule: 20
+  unité: Wh
+acv . enceinte . profil utilisation théorique:
+  formule: 3
+  unité: heure/jour
+acv . enceinte . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
+
+acv . console de salon:
+acv . console de salon . fabrication:
+  formule: 279000
+  unité: gCO2e
+acv . console de salon . distribution:
+  formule: 1200
+  unité: gCO2e
+acv . console de salon . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
+  unité: gCO2e
+acv . console de salon . fin de vie:
+  formule: 4600
+  unité: gCO2e
+acv . console de salon . durée de vie théorique:
+  formule: 6
+  unité: an
+acv . console de salon . consommation en mode actif:
+  formule: 80
+  unité: Wh
+acv . console de salon . profil utilisation théorique:
+  formule: 1
+  unité: heure/jour
+acv . console de salon . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
+
+acv . console portable:
+  titre: Enceinte connectée
+acv . console portable . fabrication:
+  formule: 64800
+  unité: gCO2e
+acv . console portable . distribution:
+  formule: 300
+  unité: gCO2e
+acv . console portable . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
+  unité: gCO2e
+acv . console portable . fin de vie:
+  formule: 500
+  unité: gCO2e
+acv . console portable . durée de vie théorique:
+  formule: 6
+  unité: an
+acv . console portable . consommation en mode actif:
+  formule: 10
+  unité: Wh
+acv . console portable . profil utilisation théorique:
+  formule: 1
+  unité: heure/jour
+acv . console portable . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh
+
+acv . imprimante:
+acv . imprimante . fabrication:
+  formule: 10500
+  unité: gCO2e
+acv . imprimante . distribution:
+  formule: 300
+  unité: gCO2e
+acv . imprimante . usage théorique:
+  formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
+  unité: gCO2e
+acv . imprimante . fin de vie:
+  formule: 10200
+  unité: gCO2e
+acv . imprimante . durée de vie théorique:
+  formule: 5
+  unité: an
+acv . imprimante . consommation en mode actif:
+  formule: 60
+  unité: Wh
+acv . imprimante . profil utilisation théorique:
+  formule: 1
+  unité: heure/jour
+acv . imprimante . consommation annuelle:
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
+  unité: kWh

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -38,13 +38,13 @@ acv . smartphone . durée de vie théorique:
   unité: an
 acv . smartphone . consommation en mode actif:
   formule: 5.6
-  unité: Wh
+  unité: W
 acv . smartphone . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . smartphone . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . tablette:
   description: |
@@ -81,13 +81,13 @@ acv . tablette . durée de vie théorique:
   unité: an
 acv . tablette . consommation en mode actif:
   formule: 15
-  unité: Wh
+  unité: W
 acv . tablette . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . tablette . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . ordinateur portable:
   description: |
@@ -124,13 +124,13 @@ acv . ordinateur portable . durée de vie théorique:
   unité: an
 acv . ordinateur portable . consommation en mode actif:
   formule: 25
-  unité: Wh
+  unité: W
 acv . ordinateur portable . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . ordinateur portable . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . TV:
   description: |
@@ -167,13 +167,13 @@ acv . TV . durée de vie théorique:
   unité: an
 acv . TV . consommation en mode actif:
   formule: 65
-  unité: Wh
+  unité: W
 acv . TV . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . TV . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . ordinateur fixe:
   description: |
@@ -210,13 +210,13 @@ acv . ordinateur fixe . durée de vie théorique:
   unité: an
 acv . ordinateur fixe . consommation en mode actif:
   formule: 50
-  unité: Wh
+  unité: W
 acv . ordinateur fixe . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . ordinateur fixe . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . écran:
   description: |
@@ -253,13 +253,13 @@ acv . écran . durée de vie théorique:
   unité: an
 acv . écran . consommation en mode actif:
   formule: 30
-  unité: Wh
+  unité: W
 acv . écran . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . écran . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . casque:
   titre: Casque de réalité virtuelle
@@ -295,13 +295,13 @@ acv . casque . durée de vie théorique:
   unité: an
 acv . casque . consommation en mode actif:
   formule: 2
-  unité: Wh
+  unité: W
 acv . casque . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . casque . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . enceinte:
   titre: Enceinte connectée
@@ -334,13 +334,13 @@ acv . enceinte . durée de vie théorique:
   unité: an
 acv . enceinte . consommation en mode actif:
   formule: 20
-  unité: Wh
+  unité: W
 acv . enceinte . profil utilisation théorique:
   formule: 3
   unité: h/jour
 acv . enceinte . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . console de salon:
 acv . console de salon . carbone:
@@ -372,13 +372,13 @@ acv . console de salon . durée de vie théorique:
   unité: an
 acv . console de salon . consommation en mode actif:
   formule: 80
-  unité: Wh
+  unité: W
 acv . console de salon . profil utilisation théorique:
   formule: 1
   unité: h/jour
 acv . console de salon . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . console portable:
 acv . console portable . carbone:
@@ -410,13 +410,13 @@ acv . console portable . durée de vie théorique:
   unité: an
 acv . console portable . consommation en mode actif:
   formule: 10
-  unité: Wh
+  unité: W
 acv . console portable . profil utilisation théorique:
   formule: 1
   unité: h/jour
 acv . console portable . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an
 
 acv . imprimante:
 acv . imprimante . carbone:
@@ -448,10 +448,10 @@ acv . imprimante . durée de vie théorique:
   unité: an
 acv . imprimante . consommation en mode actif:
   formule: 60
-  unité: Wh
+  unité: W
 acv . imprimante . profil utilisation théorique:
   formule: 1
   unité: h/jour
 acv . imprimante . consommation annuelle:
-  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
-  unité: kWh
+  formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000 W.h/kWh
+  unité: kWh/an

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -84,7 +84,7 @@ acv . tablette . consommation en mode actif:
   unité: Wh
 acv . tablette . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . tablette . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -127,7 +127,7 @@ acv . ordinateur portable . consommation en mode actif:
   unité: Wh
 acv . ordinateur portable . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . ordinateur portable . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -170,7 +170,7 @@ acv . TV . consommation en mode actif:
   unité: Wh
 acv . TV . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . TV . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -213,7 +213,7 @@ acv . ordinateur fixe . consommation en mode actif:
   unité: Wh
 acv . ordinateur fixe . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . ordinateur fixe . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -256,7 +256,7 @@ acv . écran . consommation en mode actif:
   unité: Wh
 acv . écran . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . écran . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -298,7 +298,7 @@ acv . casque . consommation en mode actif:
   unité: Wh
 acv . casque . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . casque . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -337,7 +337,7 @@ acv . enceinte . consommation en mode actif:
   unité: Wh
 acv . enceinte . profil utilisation théorique:
   formule: 3
-  unité: heure/jour
+  unité: h/jour
 acv . enceinte . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -375,7 +375,7 @@ acv . console de salon . consommation en mode actif:
   unité: Wh
 acv . console de salon . profil utilisation théorique:
   formule: 1
-  unité: heure/jour
+  unité: h/jour
 acv . console de salon . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -413,7 +413,7 @@ acv . console portable . consommation en mode actif:
   unité: Wh
 acv . console portable . profil utilisation théorique:
   formule: 1
-  unité: heure/jour
+  unité: h/jour
 acv . console portable . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh
@@ -451,7 +451,7 @@ acv . imprimante . consommation en mode actif:
   unité: Wh
 acv . imprimante . profil utilisation théorique:
   formule: 1
-  unité: heure/jour
+  unité: h/jour
 acv . imprimante . consommation annuelle:
   formule: consommation en mode actif * profil utilisation théorique * publicodes-commun . jours par an / 1000
   unité: kWh

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -21,9 +21,6 @@ acv . smartphone . carbone . distribution:
 acv . smartphone . eau . distribution:
   formule: 10
   unité: l
-acv . smartphone . carbone . usage julia:
-  formule: 600
-  unité: gCO2e
 acv . smartphone . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
@@ -64,9 +61,6 @@ acv . tablette . carbone . distribution:
 acv . tablette . eau . distribution:
   formule: 20
   unité: l
-acv . tablette . carbone . usage julia:
-  formule: 3200
-  unité: gCO2e
 acv . tablette . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
@@ -107,9 +101,6 @@ acv . ordinateur portable . carbone . distribution:
 acv . ordinateur portable . eau . distribution:
   formule: 60
   unité: l
-acv . ordinateur portable . carbone . usage julia:
-  formule: 8300
-  unité: gCO2e
 acv . ordinateur portable . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
@@ -150,9 +141,6 @@ acv . TV . carbone . distribution:
 acv . TV . eau . distribution:
   formule: 10
   unité: l
-acv . TV . carbone . usage julia:
-  formule: 92700
-  unité: gCO2e
 acv . TV . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
@@ -193,9 +181,6 @@ acv . ordinateur fixe . carbone . distribution:
 acv . ordinateur fixe . eau . distribution:
   formule: 10
   unité: l
-acv . ordinateur fixe . carbone . usage julia:
-  formule: 34100
-  unité: gCO2e
 acv . ordinateur fixe . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e
@@ -236,9 +221,6 @@ acv . écran . carbone . distribution:
 acv . écran . eau . distribution:
   formule: 5
   unité: l
-acv . écran . carbone . usage julia:
-  formule: 23900
-  unité: gCO2e
 acv . écran . carbone . usage théorique:
   formule: consommation annuelle * publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e * durée de vie théorique
   unité: gCO2e

--- a/rules/acv-terminaux.publicodes
+++ b/rules/acv-terminaux.publicodes
@@ -30,6 +30,7 @@ acv . smartphone . carbone . fin de vie:
 acv . smartphone . eau . fin de vie:
   formule: 58300
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . smartphone . durée de vie théorique:
   formule: 2.5
   unité: an
@@ -70,6 +71,7 @@ acv . tablette . carbone . fin de vie:
 acv . tablette . eau . fin de vie:
   formule: 61500
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . tablette . durée de vie théorique:
   formule: 3
   unité: an
@@ -110,6 +112,7 @@ acv . ordinateur portable . carbone . fin de vie:
 acv . ordinateur portable . eau . fin de vie:
   formule: 638400
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . ordinateur portable . durée de vie théorique:
   formule: 5
   unité: an
@@ -150,6 +153,7 @@ acv . TV . carbone . fin de vie:
 acv . TV . eau . fin de vie:
   formule: 1316400
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . TV . durée de vie théorique:
   formule: 8
   unité: an
@@ -190,6 +194,7 @@ acv . ordinateur fixe . carbone . fin de vie:
 acv . ordinateur fixe . eau . fin de vie:
   formule: 2070000
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . ordinateur fixe . durée de vie théorique:
   formule: 6
   unité: an
@@ -230,6 +235,7 @@ acv . écran . carbone . fin de vie:
 acv . écran . eau . fin de vie:
   formule: 677200
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . écran . durée de vie théorique:
   formule: 6
   unité: an
@@ -271,7 +277,9 @@ acv . casque . carbone . fin de vie:
 acv . casque . eau . fin de vie:
   formule: -23600
   unité: l
-  note: Curieux cette valeur négative, la seule parmi les appareils ici.
+  note: |
+    Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
+    Curieux cette valeur négative, la seule parmi les appareils ici.
 acv . casque . durée de vie théorique:
   formule: 5
   unité: an
@@ -311,6 +319,7 @@ acv . enceinte . carbone . fin de vie:
 acv . enceinte . eau . fin de vie:
   formule: 112000
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . enceinte . durée de vie théorique:
   formule: 5
   unité: an
@@ -349,6 +358,7 @@ acv . console de salon . carbone . fin de vie:
 acv . console de salon . eau . fin de vie:
   formule: 907000
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . console de salon . durée de vie théorique:
   formule: 6
   unité: an
@@ -387,6 +397,7 @@ acv . console portable . carbone . fin de vie:
 acv . console portable . eau . fin de vie:
   formule: 112000
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . console portable . durée de vie théorique:
   formule: 6
   unité: an
@@ -425,6 +436,7 @@ acv . imprimante . carbone . fin de vie:
 acv . imprimante . eau . fin de vie:
   formule: 2400000
   unité: l
+  note: Selon le service Numérique ADEME, les données de la fin de vie pour l'indicateur eau ne sont pas fiables.
 acv . imprimante . durée de vie théorique:
   formule: 5
   unité: an

--- a/rules/data center.publicodes
+++ b/rules/data center.publicodes
@@ -92,13 +92,15 @@ construction data center:
 
 construction data center . serveur:
   formule: facteur d'allocation * serveur . construction
-
+  unité: gCO2e
+  
 construction data center . serveur . facteur d'allocation:
   formule: 0
   note: A remplacer dans le recalcul
 
 construction data center . firewall:
   formule: facteur d'allocation * firewall . construction
+  unité: gCO2e
 
 construction data center . firewall . facteur d'allocation:
   formule: 0.0358 * serveur . facteur d'allocation
@@ -106,6 +108,7 @@ construction data center . firewall . facteur d'allocation:
 
 construction data center . switch:
   formule: facteur d'allocation * switch . construction
+  unité: gCO2e
 
 construction data center . switch . facteur d'allocation:
   formule: 1.468 * serveur . facteur d'allocation
@@ -113,7 +116,8 @@ construction data center . switch . facteur d'allocation:
 
 construction data center . routeur:
   formule: facteur d'allocation * routeur . construction
-
+  unité: gCO2e
+  
 construction data center . routeur . facteur d'allocation:
   formule: 0.286 * serveur . facteur d'allocation
   référence: considérant 0,286 routeurs par serveur (données APL Datacenter basées sur une moyenne du marché)
@@ -128,6 +132,7 @@ construction data center . stockage . facteur d'allocation:
 
 construction data center . équipements support:
   formule: facteur d'allocation * équipements support . construction
+  unité: gCO2e
 
 construction data center . équipements support . facteur d'allocation:
   formule: 0.68 m2 * serveur . facteur d'allocation * serveur . durée de vie / équipements support . durée de vie

--- a/rules/email.publicodes
+++ b/rules/email.publicodes
@@ -20,7 +20,7 @@ email . taille:
   unité: Mo
 
 email . taille en Go:
-  formule: taille / 1024
+  formule: taille / 1024 Mo/Go
   unité: Go
 
 email . destinataires:
@@ -62,7 +62,7 @@ email . taux moyen de remplissage du stockage:
 email . nombre de mails envoyés et reçus par jour et par personne:
   titre: Nombre de mails reçus et envoyés par jour et par personne
   question: Combien de mails envoyés et réçus par jour et par personne ?
-  par défaut: 117.7
+  par défaut: 117.7 /jour
   référence: Email Statistics Report, 2015-2019, The Radicati group
 
 email . terminaux:
@@ -106,7 +106,7 @@ email . appareil . moyenne utilisation tablette: 8%
 email . appareil . moyenne utilisation smartphone: 45%
 
 email . appareil . durée totale sollicitation:
-  formule: terminaux . temps écriture en heure + terminaux . temps lecture en heure
+  formule: terminaux . temps écriture en h + terminaux . temps lecture en h
 
 email . terminaux . temps écriture:
   titre: Temps d'écriture du mail
@@ -114,9 +114,9 @@ email . terminaux . temps écriture:
   par défaut: 3
   unité: minute
 
-email . terminaux . temps écriture en heure:
-  formule: temps écriture / 60
-  unité: heure
+email . terminaux . temps écriture en h:
+  formule: temps écriture / 60 minute/h
+  unité: h
 
 email . terminaux . pourcentage lecture:
   titre: Taux de lecture du mail
@@ -126,16 +126,16 @@ email . terminaux . pourcentage lecture:
 email . terminaux . temps lecture récepteur:
   titre: Temps de lecture du mail
   question: Quel est le temps de lecture du mail ?
-  par défaut: 10 / 60
+  par défaut: 10 minute / 60
   unité: minute
 
 email . terminaux . temps lecture total:
   formule: destinataires * pourcentage lecture * temps lecture récepteur
   unité: minute
 
-email . terminaux . temps lecture en heure:
-  formule: temps lecture total / 60
-  unité: heure
+email . terminaux . temps lecture en h:
+  formule: temps lecture total / 60 minute/h
+  unité: h
 
 email . terminaux . usage:
   valeur: usage réel
@@ -217,7 +217,7 @@ email . transmission . redondances sauvegarde:
   # formule: (redondances sauvegarde émetteur + destinataires * redondances sauvegarde récepteur) * taille en Go * facteur réseau
   formule: destinataires * taille en Go * facteur réseau * (1 + redondances sauvegarde émetteur + redondances sauvegarde récepteur)
   note: Formule peu documentée, non comprise, je pense que ce poste est à précisier/définir
-  unité: Go
+  unité: gCO2e
 
 email . transmission . redondances sauvegarde . facteur réseau:
   titre: Facteur réseau transmission sauvegarde
@@ -264,7 +264,7 @@ email . data center . construction . émetteur:
     construction data center . stockage . facteur d'allocation: data center . construction . émetteur . facteur d'allocation stockage
 
 email . data center . construction . émetteur . facteur d'allocation serveur:
-  formule: 1 / (serveur . nombre d'utilisateurs par serveur * nombre de mails envoyés et reçus par jour et par personne * 365 * serveur . durée de vie)
+  formule: 1 / (serveur . nombre d'utilisateurs par serveur * nombre de mails envoyés et reçus par jour et par personne * 365 jour/an * serveur . durée de vie)
   note: Allocation au nombre de mail par an et par utilisateur, et d'utilisateur par serveur
 
 email . data center . construction . émetteur . facteur d'allocation stockage:
@@ -299,7 +299,7 @@ email . data center . usage . émetteur:
   unité: gCO2e
 
 email . data center . usage . émetteur . consommation électricité réelle:
-  formule: consommation électricité * serveur . PUE mails / 1000
+  formule: consommation électricité * serveur . PUE mails / 1000 Wh/kWh
   unité: kWh
 
 email . data center . usage . émetteur . consommation électricité:
@@ -307,11 +307,11 @@ email . data center . usage . émetteur . consommation électricité:
   unité: Wh
 
 email . data center . usage . émetteur . consommation électricité . consommation serveur par mail:
-  formule: serveur . puissance par utilisateur * 24 / nombre de mails envoyés et reçus par jour et par personne
+  formule: serveur . puissance par utilisateur * 24 h/jour / nombre de mails envoyés et reçus par jour et par personne * 1 Wh/W.h
   unité: Wh
 
 email . data center . usage . émetteur . consommation électricité . consommation serveur stockage:
-  formule: taille * redondances sauvegarde émetteur / (serveur . capacité * taux moyen de remplissage du stockage) * stockage . puissance en mode actif * 24 * 365 * durée stockage mail
+  formule: taille * redondances sauvegarde émetteur / (serveur . capacité * taux moyen de remplissage du stockage) * stockage . puissance en mode actif * 24 h/jour * 365 jour/an * durée stockage mail * 1 Wh/W.h
   unité: Wh
 
 email . data center . usage . récepteur:

--- a/rules/fichier.publicodes
+++ b/rules/fichier.publicodes
@@ -57,7 +57,7 @@ fichier . data center:
 fichier . data center . construction:
   valeur: construction data center
   contexte:
-    construction data center . serveur . facteur d'allocation: facteur allocation serveur
+    construction data center . serveur . facteur d'allocation: facteur allocation serveur * fichier . taille
     construction data center . stockage . facteur d'allocation: 0
   note: Stockage non pris en compte, considérant que le fichier peut être partagé par un grand nombre de personnes
 
@@ -75,11 +75,11 @@ fichier . data center . usage:
     il a été considéré par hypothèse que celle-ci est similaire à celle de la vidéo en ligne.
 
 fichier . data center . usage . consommation électricité:
-  formule: taille * électricité par Go en Wh / 1000
+  formule: taille * électricité par Go en Wh / 1000 Wh/kWh
   unité: kWh
 
 fichier . data center . usage . électricité par Go en Wh:
-  formule: électricité par Go * 1000000
+  formule: électricité par Go * 1000000 Wh/MWh
   unité: Wh/Go
 
 fichier . data center . usage . électricité par Go:

--- a/rules/mixs-IEA.publicodes
+++ b/rules/mixs-IEA.publicodes
@@ -1,6 +1,6 @@
 importer!:
   depuis:
-    nom: "@incubateur-ademe/publicodes-commun"
+    nom: '@incubateur-ademe/publicodes-commun'
     url: https://github.com/incubateur-ademe/publicodes-commun
   les règles:
     - intensité électricité

--- a/rules/mixs-IEA.publicodes
+++ b/rules/mixs-IEA.publicodes
@@ -9,7 +9,7 @@ importer!:
   note: FE issus de l'IEA, correspond à priori au FE de production de mix électrique
 
 électricité . FE France:
-  formule: publicodes-commun . intensité électricité * 1000
+  formule: publicodes-commun . intensité électricité * 1000 gCO2e/kgCO2e
   # formule: 66.96
   unité: gCO2e/kWh
 

--- a/rules/recherche web.publicodes
+++ b/rules/recherche web.publicodes
@@ -17,15 +17,15 @@ recherche web:
 recherche web . temps de saisie:
   titre: Temps de saisie de la requête
   question: Quelle est la durée de la saisie ?
-  par défaut: 50 / 60
+  par défaut: 50 minute / 60
   unité: minute
   référence: |
     "Analyse comparée des impacts environnementaux de la communication par voie électronique - Volet requête web : Rapport final"
     BioIS pour l'ADEME, 18 février 2011
 
 recherche web . temps de saisie en heure:
-  formule: temps de saisie / 60
-  unité: heure
+  formule: temps de saisie / 60 minute/h
+  unité: h
 
 recherche web . taille de la requete:
   titre: Taille de la requête
@@ -35,11 +35,11 @@ recherche web . taille de la requete:
   note: Mesure Negaoctet
 
 recherche web . taille de la requete en Mo:
-  formule: taille de la requete / 1024
+  formule: taille de la requete / 1024 ko/Mo
   unité: Mo
 
 recherche web . taille de la requete en Go:
-  formule: taille de la requete / 1024 / 1024
+  formule: taille de la requete / 1024 ko/Mo / 1024 Mo/Go
   unité: Go
 
 recherche web . taille de la page:
@@ -51,11 +51,11 @@ recherche web . taille de la page:
     Basé sur la taille moyenne des pages des 10 recherches les plus effectuées en 2021 (source : google trends)
 
 recherche web . taille de la page en Mo:
-  formule: taille de la page / 1024
+  formule: taille de la page / 1024 ko/Mo
   unité: Mo
 
 recherche web . taille de la page en Go:
-  formule: taille de la page / 1024 / 1024
+  formule: taille de la page / 1024 ko/Mo / 1024 Mo/Go
   unité: Go
 
 recherche web . temps de consultation:
@@ -68,8 +68,8 @@ recherche web . temps de consultation:
     BioIS pour l'ADEME, 18 février 2011
 
 recherche web . temps de consultation en heure:
-  formule: temps de consultation / 60
-  unité: heure
+  formule: temps de consultation / 60 minute/h
+  unité: h
 
 recherche web . nombre de pages de résultats lues:
   titre: Nombre de pages de résultats consultées
@@ -125,7 +125,7 @@ recherche web . appareil . moyenne utilisation smartphone: 45%
 
 recherche web . appareil . durée totale sollicitation:
   formule: temps de saisie en heure + temps de consultation en heure * nombre de pages de résultats lues
-  unité: heure
+  unité: h
 
 recherche web . terminaux . usage:
   valeur: usage réel
@@ -188,7 +188,7 @@ recherche web . data center:
       - Transfert des informations via le routeur et serveur d’entree du Data Center ;
 
 recherche web . data center . allocation serveur par Mo:
-  formule: 1 / 10052100000
+  formule: 1 / 10052100000 Mo
   note: |
     "Allocation par rapport au volume d'information traité par les serveurs, avec :
     Q informations traitées (Mo) = (taux de transfert des ports ethernet (Mo/s)) x 3600 x Temps d’utilisation (h/jr) x Taux moyen d’utilisation x Duree de vie en jours
@@ -227,5 +227,5 @@ recherche web . data center . usage . consommation totale serveur:
   formule: consommation annuelle serveur * serveur . durée de vie
 
 recherche web . data center . usage . consommation annuelle serveur:
-  formule: serveur . puissance en mode actif * 24 * 365 / 1000
+  formule: serveur . puissance en mode actif * 24 h/jour * 365 jour/an / 1000 Wh/kWh * 1 Wh/W.h
   unité: kWh/an

--- a/rules/streaming.publicodes
+++ b/rules/streaming.publicodes
@@ -36,7 +36,7 @@ streaming . qualité . facteur qualité:
         alors: 3
       - si: qualité = 'ultra HD'
         alors: 7
-  unité: Go/heure
+  unité: Go/h
 
 streaming . durée:
   titre: Temps de visionnage
@@ -46,8 +46,8 @@ streaming . durée:
 
 streaming . durée en heure:
   titre: Temps de visionnage en heure
-  formule: durée / 60
-  unité: heure
+  formule: durée / 60 minute/h
+  unité: h
 
 streaming . taille:
   titre: Taille de la vidéo
@@ -149,10 +149,11 @@ streaming . data center:
 streaming . data center . construction:
   valeur: construction data center
   contexte:
-    construction data center . serveur . facteur d'allocation: facteur d'allocation serveur
+    construction data center . serveur . facteur d'allocation: facteur d'allocation serveur * streaming . durée en heure
   note: Stockage négligé car divisé entre un nombre très important de visionnage
 
-streaming . data center . construction . facteur d'allocation serveur: nombre de serveurs / nombre d'heures de visionnage par an / serveur . durée de vie
+streaming . data center . construction . facteur d'allocation serveur:
+  formule: nombre de serveurs / nombre d'heures de visionnage par an / serveur . durée de vie
 
 streaming . data center . usage:
   valeur: usage data center
@@ -161,11 +162,11 @@ streaming . data center . usage:
   unité: gCO2e
 
 streaming . data center . usage . consommation électricité:
-  formule: taille * électricité par Go en Wh / 1000
+  formule: taille * électricité par Go en Wh / 1000 Wh/kWh
   unité: kWh
 
 streaming . data center . usage . électricité par Go en Wh:
-  formule: électricité par Go * 1000000
+  formule: électricité par Go * 1000000 Wh/MWh
   unité: Wh/Go
 
 streaming . data center . usage . électricité par Go:
@@ -179,21 +180,22 @@ streaming . data center . volume total de transfert de données:
   formule: nombre d'heures de visionnage par an * consommation de donnée moyenne par heure de visionnage
 
 streaming . data center . puissance installée avant PUE:
-  formule: (électricité directe consommée par an + électricité indirecte consommée par an) / serveur . PUE streaming * 1000000 / 365 / 24
+  formule: (électricité directe consommée par an + électricité indirecte consommée par an) / serveur . PUE streaming * 1000000 W.h/MWh / 365 jour/an / 24 h/jour
+  unité: W
 
 streaming . électricité directe consommée par an:
   formule: 94000
-  unité: MWh
+  unité: MWh/an
   référence: Netflix Environmental Social Governance 2019
 
 streaming . électricité indirecte consommée par an:
   formule: 357000
-  unité: MWh
+  unité: MWh/an
   référence: Netflix Environmental Social Governance 2019
 
 streaming . consommation de donnée moyenne par heure de visionnage:
   formule: 1.9
-  unité: Go
+  unité: Go/h
   référence: |
     "Factcheck: What is the carbon footprint of streaming video on Netflix?" CarbonBrief
 
@@ -203,7 +205,7 @@ streaming . nombre d'utilisateurs par an:
     "Factcheck: What is the carbon footprint of streaming video on Netflix?" CarbonBrief
 
 streaming . nombre d'heures de visionnage par an:
-  formule: 2 * 365 * nombre d'utilisateurs par an
+  formule: 2 h/jour * 365 jour/an * nombre d'utilisateurs par an
   note: |
     On a ici une hypothèse importante: les utilisateurs passeraient 2 heures sur Netflix par jour en moyenne.
   référence: |

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -1,6 +1,6 @@
 importer!:
   depuis:
-    nom: "@incubateur-ademe/publicodes-commun"
+    nom: '@incubateur-ademe/publicodes-commun'
     url: https://github.com/incubateur-ademe/publicodes-commun
   les règles:
     - jours par an
@@ -21,9 +21,7 @@ construction réelle:
       - si: appareil par défaut = 'moyenne'
         alors: moyenne
   reference: |
-    Les données relatives à la construction et l'amortissement des appareils sont tirés 
-    de [cette étude](https://librairie.ademe.fr/dechets-economie-circulaire/1189-modelisation-et-evaluation-des-impacts-environnementaux-de-produits-de-consommation-et-biens-d-equipement.html)
-    (facteurs d'émission, durée de vie)
+    Les données relatives à la construction et l'amortissement des appareils sont tirées du dernier excel Negaoctet disponible dans la Base Impact.
   unité: gCO2e
 
 construction réelle . moyenne:
@@ -132,7 +130,7 @@ moyenne utilisation TV par défaut:
 
 smartphone:
 smartphone . construction:
-  formule: 30526
+  formule: acv . smartphone . fabrication + acv . smartphone . distribution
   unité: gCO2e
 
 smartphone . durée d'usage:
@@ -143,11 +141,7 @@ smartphone . durée de vie:
   titre: Durée de vie smartphone
   question: Quelle est la durée de vie du smartphone ?
   unité: an
-  par défaut: smartphone . durée de vie par défaut
-
-smartphone . durée de vie par défaut:
-  par défaut: 4
-  unité: an
+  par défaut: acv . smartphone . durée de vie théorique
 
 smartphone . profil utilisation:
   titre: Profil d'utilisation smartphone
@@ -165,7 +159,7 @@ smartphone . consommation en mode actif:
 
 tablette:
 tablette . construction:
-  formule: 44500
+  formule: acv . tablette . fabrication + acv . tablette . distribution
   unité: gCO2e
 
 tablette . durée d'usage:
@@ -176,11 +170,7 @@ tablette . durée de vie:
   titre: Durée de vie tablette
   question: Quelle est la durée de vie de la tablette ?
   unité: an
-  par défaut: tablette . durée de vie par défaut
-
-tablette . durée de vie par défaut:
-  par défaut: 3
-  unité: an
+  par défaut: acv . tablette . durée de vie théorique
 
 tablette . profil utilisation:
   titre: Profil d'utilisation tablette
@@ -198,7 +188,7 @@ tablette . consommation en mode actif:
 
 ordinateur portable:
 ordinateur portable . construction:
-  formule: 134700
+  formule: acv . ordinateur portable . fabrication + acv . ordinateur portable . distribution
   unité: gCO2e
 
 ordinateur portable . durée d'usage:
@@ -209,11 +199,7 @@ ordinateur portable . durée de vie:
   titre: Durée de vie ordinateur portable
   question: Quelle est la durée de vie de l'ordinateur portable ?
   unité: an
-  par défaut: ordinateur portable . durée de vie par défaut
-
-ordinateur portable . durée de vie par défaut:
-  par défaut: 6
-  unité: an
+  par défaut: acv . ordinateur portable . durée de vie théorique
 
 ordinateur portable . profil utilisation:
   titre: Profil d'utilisation ordinateur portable
@@ -231,7 +217,7 @@ ordinateur portable . consommation en mode actif:
 
 TV:
 TV . construction:
-  formule: 349870
+  formule: acv . TV . fabrication + acv . TV . distribution
   unité: gCO2e
 
 TV . durée d'usage:
@@ -242,11 +228,7 @@ TV . durée de vie:
   titre: Durée de vie TV
   question: Quelle est la durée de vie de la TV ?
   unité: an
-  par défaut: TV . durée de vie par défaut
-
-TV . durée de vie par défaut:
-  par défaut: 8
-  unité: an
+  par défaut: acv . TV . durée de vie théorique
 
 TV . profil utilisation:
   titre: Profil d'utilisation TV
@@ -264,12 +246,8 @@ TV . consommation en mode actif:
 
 ordinateur fixe:
 ordinateur fixe . construction:
-  formule: 169080
+  formule: acv . ordinateur fixe . fabrication + acv . ordinateur fixe . distribution
   unité: gCO2e
-
-ordinateur fixe . durée de vie par défaut:
-  par défaut: 6
-  unité: an
 
 ordinateur fixe . consommation en mode actif:
   formule: 50
@@ -277,12 +255,8 @@ ordinateur fixe . consommation en mode actif:
 
 écran:
 écran . construction:
-  formule: 247840
+  formule: acv . écran . fabrication + acv . écran . distribution
   unité: gCO2e
-
-écran . durée de vie par défaut:
-  par défaut: 6
-  unité: an
 
 écran . consommation en mode actif:
   formule: 30
@@ -304,11 +278,10 @@ ordinateur et écran . durée de vie:
   titre: Durée de vie ordinateur et écran
   question: Quelle est la durée de vie de votre ordinateur et écran ?
   unité: an
-  par défaut: ordinateur et écran . durée de vie par défaut
-
-ordinateur et écran . durée de vie par défaut:
-  par défaut: (ordinateur fixe . durée de vie par défaut + écran . durée de vie par défaut) / 2
-  unité: an
+  par défaut:
+    moyenne:
+      - acv . ordinateur fixe . durée de vie théorique
+      - acv . écran . durée de vie théorique
 
 ordinateur et écran . profil utilisation:
   titre: Profil d'utilisation ordinateur et écran

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -130,7 +130,7 @@ moyenne utilisation TV par défaut:
 
 smartphone:
 smartphone . construction:
-  formule: acv . smartphone . fabrication + acv . smartphone . distribution
+  formule: acv . smartphone . carbone . fabrication + acv . smartphone . carbone . distribution
   unité: gCO2e
 
 smartphone . durée d'usage:
@@ -151,7 +151,7 @@ smartphone . profil utilisation:
 
 tablette:
 tablette . construction:
-  formule: acv . tablette . fabrication + acv . tablette . distribution
+  formule: acv . tablette . carbone . fabrication + acv . tablette . carbone . distribution
   unité: gCO2e
 
 tablette . durée d'usage:
@@ -172,7 +172,7 @@ tablette . profil utilisation:
 
 ordinateur portable:
 ordinateur portable . construction:
-  formule: acv . ordinateur portable . fabrication + acv . ordinateur portable . distribution
+  formule: acv . ordinateur portable . carbone . fabrication + acv . ordinateur portable . carbone . distribution
   unité: gCO2e
 
 ordinateur portable . durée d'usage:
@@ -193,7 +193,7 @@ ordinateur portable . profil utilisation:
 
 TV:
 TV . construction:
-  formule: acv . TV . fabrication + acv . TV . distribution
+  formule: acv . TV . carbone . fabrication + acv . TV . carbone . distribution
   unité: gCO2e
 
 TV . durée d'usage:
@@ -214,12 +214,12 @@ TV . profil utilisation:
 
 ordinateur fixe:
 ordinateur fixe . construction:
-  formule: acv . ordinateur fixe . fabrication + acv . ordinateur fixe . distribution
+  formule: acv . ordinateur fixe . carbone . fabrication + acv . ordinateur fixe . carbone . distribution
   unité: gCO2e
 
 écran:
 écran . construction:
-  formule: acv . écran . fabrication + acv . écran . distribution
+  formule: acv . écran . carbone . fabrication + acv . écran . carbone . distribution
   unité: gCO2e
 
 ordinateur et écran:

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -91,15 +91,15 @@ usage réel . consommation électricité par heure:
   formule:
     variations:
       - si: appareil par défaut = 'smartphone'
-        alors: smartphone . consommation en mode actif
+        alors: acv . smartphone . consommation en mode actif
       - si: appareil par défaut = 'tablette'
-        alors: tablette . consommation en mode actif
+        alors: acv . tablette . consommation en mode actif
       - si: appareil par défaut = 'ordinateur portable'
-        alors: ordinateur portable . consommation en mode actif
+        alors: acv . ordinateur portable . consommation en mode actif
       - si: appareil par défaut = 'ordinateur et écran'
         alors: ordinateur et écran . consommation en mode actif
       - si: appareil par défaut = 'TV'
-        alors: TV . consommation en mode actif
+        alors: acv . TV . consommation en mode actif
       - sinon: consommation en mode actif moyenne
   unité: Wh
 
@@ -107,10 +107,10 @@ usage réel . consommation en mode actif moyenne:
   formule:
     somme:
       - moyenne utilisation ordinateur et écran par défaut * ordinateur et écran . consommation en mode actif
-      - moyenne utilisation ordinateur portable par défaut * ordinateur portable . consommation en mode actif
-      - moyenne utilisation tablette par défaut * tablette . consommation en mode actif
-      - moyenne utilisation smartphone par défaut * smartphone . consommation en mode actif
-      - moyenne utilisation TV par défaut * TV . consommation en mode actif
+      - moyenne utilisation ordinateur portable par défaut * acv . ordinateur portable . consommation en mode actif
+      - moyenne utilisation tablette par défaut * acv . tablette . consommation en mode actif
+      - moyenne utilisation smartphone par défaut * acv . smartphone . consommation en mode actif
+      - moyenne utilisation TV par défaut * acv . TV . consommation en mode actif
 
 appareil par défaut:
   par défaut: "'moyenne'"
@@ -147,15 +147,7 @@ smartphone . profil utilisation:
   titre: Profil d'utilisation smartphone
   question: Quelle est le profil d'utilisation du smartphone ?
   unité: heure/jour
-  par défaut: smartphone . profil utilisation par défaut
-
-smartphone . profil utilisation par défaut:
-  formule: 3
-  unité: heure/jour
-
-smartphone . consommation en mode actif:
-  formule: 5.6
-  unité: Wh
+  par défaut: acv . smartphone . profil utilisation théorique
 
 tablette:
 tablette . construction:
@@ -176,15 +168,7 @@ tablette . profil utilisation:
   titre: Profil d'utilisation tablette
   question: Quelle est le profil d'utilisation de la tablette ?
   unité: heure/jour
-  par défaut: tablette . profil utilisation par défaut
-
-tablette . profil utilisation par défaut:
-  formule: 3
-  unité: heure/jour
-
-tablette . consommation en mode actif:
-  formule: 15
-  unité: Wh
+  par défaut: acv . tablette . profil utilisation théorique
 
 ordinateur portable:
 ordinateur portable . construction:
@@ -205,15 +189,7 @@ ordinateur portable . profil utilisation:
   titre: Profil d'utilisation ordinateur portable
   question: Quelle est le profil d'utilisation de l'ordinateur portable ?
   unité: heure/jour
-  par défaut: ordinateur portable . profil utilisation par défaut
-
-ordinateur portable . profil utilisation par défaut:
-  formule: 3
-  unité: heure/jour
-
-ordinateur portable . consommation en mode actif:
-  formule: 25
-  unité: Wh
+  par défaut: acv . ordinateur portable . profil utilisation théorique
 
 TV:
 TV . construction:
@@ -234,33 +210,17 @@ TV . profil utilisation:
   titre: Profil d'utilisation TV
   question: Quelle est le profil d'utilisation de la TV ?
   unité: heure/jour
-  par défaut: TV . profil utilisation par défaut
-
-TV . profil utilisation par défaut:
-  formule: 3
-  unité: heure/jour
-
-TV . consommation en mode actif:
-  formule: 65
-  unité: Wh
+  par défaut: acv . TV . profil utilisation théorique
 
 ordinateur fixe:
 ordinateur fixe . construction:
   formule: acv . ordinateur fixe . fabrication + acv . ordinateur fixe . distribution
   unité: gCO2e
 
-ordinateur fixe . consommation en mode actif:
-  formule: 50
-  unité: Wh
-
 écran:
 écran . construction:
   formule: acv . écran . fabrication + acv . écran . distribution
   unité: gCO2e
-
-écran . consommation en mode actif:
-  formule: 30
-  unité: Wh
 
 ordinateur et écran:
 ordinateur et écran . construction:
@@ -287,15 +247,18 @@ ordinateur et écran . profil utilisation:
   titre: Profil d'utilisation ordinateur et écran
   question: Quelle est le profil d'utilisation de l'ordinateur et écran ?
   unité: heure/jour
-  par défaut: ordinateur et écran . profil utilisation par défaut
+  par défaut: ordinateur et écran . profil utilisation théorique
 
-ordinateur et écran . profil utilisation par défaut:
-  formule: 3
+ordinateur et écran . profil utilisation théorique:
+  formule:
+    moyenne:
+      - acv . ordinateur fixe . profil utilisation théorique
+      - acv . écran . profil utilisation théorique
   unité: heure/jour
 
 ordinateur et écran . consommation en mode actif:
   formule:
     somme:
-      - ordinateur fixe . consommation en mode actif
-      - écran . consommation en mode actif
+      - acv . ordinateur fixe . consommation en mode actif
+      - acv . écran . consommation en mode actif
   unité: Wh

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -84,7 +84,7 @@ usage réel . région:
   par défaut: "'France'"
 
 usage réel . consommation électricité:
-  formule: durée en heure par défaut * consommation électricité par heure / 1000
+  formule: durée en heure par défaut * consommation électricité par heure / 1000 Wh/kWh
   unité: kWh
 
 usage réel . consommation électricité par heure:
@@ -116,7 +116,7 @@ appareil par défaut:
   par défaut: "'moyenne'"
 durée en heure par défaut:
   par défaut: 0
-  unité: heure
+  unité: h
 moyenne utilisation ordinateur et écran par défaut:
   par défaut: 0%
 moyenne utilisation ordinateur portable par défaut:
@@ -135,7 +135,7 @@ smartphone . construction:
 
 smartphone . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: heure
+  unité: h
 
 smartphone . durée de vie:
   titre: Durée de vie smartphone
@@ -146,7 +146,7 @@ smartphone . durée de vie:
 smartphone . profil utilisation:
   titre: Profil d'utilisation smartphone
   question: Quelle est le profil d'utilisation du smartphone ?
-  unité: heure/jour
+  unité: h/jour
   par défaut: acv . smartphone . profil utilisation théorique
 
 tablette:
@@ -156,7 +156,7 @@ tablette . construction:
 
 tablette . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: heure
+  unité: h
 
 tablette . durée de vie:
   titre: Durée de vie tablette
@@ -167,7 +167,7 @@ tablette . durée de vie:
 tablette . profil utilisation:
   titre: Profil d'utilisation tablette
   question: Quelle est le profil d'utilisation de la tablette ?
-  unité: heure/jour
+  unité: h/jour
   par défaut: acv . tablette . profil utilisation théorique
 
 ordinateur portable:
@@ -177,7 +177,7 @@ ordinateur portable . construction:
 
 ordinateur portable . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: heure
+  unité: h.an
 
 ordinateur portable . durée de vie:
   titre: Durée de vie ordinateur portable
@@ -188,7 +188,7 @@ ordinateur portable . durée de vie:
 ordinateur portable . profil utilisation:
   titre: Profil d'utilisation ordinateur portable
   question: Quelle est le profil d'utilisation de l'ordinateur portable ?
-  unité: heure/jour
+  unité: h/jour
   par défaut: acv . ordinateur portable . profil utilisation théorique
 
 TV:
@@ -198,7 +198,7 @@ TV . construction:
 
 TV . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: heure
+  unité: h
 
 TV . durée de vie:
   titre: Durée de vie TV
@@ -209,7 +209,7 @@ TV . durée de vie:
 TV . profil utilisation:
   titre: Profil d'utilisation TV
   question: Quelle est le profil d'utilisation de la TV ?
-  unité: heure/jour
+  unité: h/jour
   par défaut: acv . TV . profil utilisation théorique
 
 ordinateur fixe:
@@ -232,7 +232,7 @@ ordinateur et écran . construction:
 
 ordinateur et écran . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: heure
+  unité: h
 
 ordinateur et écran . durée de vie:
   titre: Durée de vie ordinateur et écran
@@ -246,7 +246,7 @@ ordinateur et écran . durée de vie:
 ordinateur et écran . profil utilisation:
   titre: Profil d'utilisation ordinateur et écran
   question: Quelle est le profil d'utilisation de l'ordinateur et écran ?
-  unité: heure/jour
+  unité: h/jour
   par défaut: ordinateur et écran . profil utilisation théorique
 
 ordinateur et écran . profil utilisation théorique:
@@ -254,7 +254,7 @@ ordinateur et écran . profil utilisation théorique:
     moyenne:
       - acv . ordinateur fixe . profil utilisation théorique
       - acv . écran . profil utilisation théorique
-  unité: heure/jour
+  unité: h/jour
 
 ordinateur et écran . consommation en mode actif:
   formule:

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -3,7 +3,8 @@ importer!:
     nom: '@incubateur-ademe/publicodes-commun'
     url: https://github.com/incubateur-ademe/publicodes-commun
   les règles:
-    - jours par an
+    - jours par an:
+        unité: jour/an
 
 construction réelle:
   formule:
@@ -84,7 +85,7 @@ usage réel . région:
   par défaut: "'France'"
 
 usage réel . consommation électricité:
-  formule: durée en heure par défaut * consommation électricité par heure / 1000 Wh/kWh
+  formule: consommation électricité par heure * durée en heure par défaut / 1000 W.h/kWh
   unité: kWh
 
 usage réel . consommation électricité par heure:
@@ -101,7 +102,7 @@ usage réel . consommation électricité par heure:
       - si: appareil par défaut = 'TV'
         alors: acv . TV . consommation en mode actif
       - sinon: consommation en mode actif moyenne
-  unité: Wh
+  unité: W
 
 usage réel . consommation en mode actif moyenne:
   formule:
@@ -177,7 +178,7 @@ ordinateur portable . construction:
 
 ordinateur portable . durée d'usage:
   formule: publicodes-commun . jours par an * durée de vie * profil utilisation
-  unité: h.an
+  unité: h
 
 ordinateur portable . durée de vie:
   titre: Durée de vie ordinateur portable
@@ -261,4 +262,4 @@ ordinateur et écran . consommation en mode actif:
     somme:
       - acv . ordinateur fixe . consommation en mode actif
       - acv . écran . consommation en mode actif
-  unité: Wh
+  unité: W

--- a/rules/terminaux.publicodes
+++ b/rules/terminaux.publicodes
@@ -131,7 +131,11 @@ moyenne utilisation TV par défaut:
 
 smartphone:
 smartphone . construction:
-  formule: acv . smartphone . carbone . fabrication + acv . smartphone . carbone . distribution
+  formule: 
+    somme:
+      - acv . smartphone . carbone . fabrication
+      - acv . smartphone . carbone . distribution
+      - acv . smartphone . carbone . fin de vie
   unité: gCO2e
 
 smartphone . durée d'usage:
@@ -152,7 +156,11 @@ smartphone . profil utilisation:
 
 tablette:
 tablette . construction:
-  formule: acv . tablette . carbone . fabrication + acv . tablette . carbone . distribution
+  formule: 
+    somme:
+      - acv . tablette . carbone . fabrication
+      - acv . tablette . carbone . distribution
+      - acv . tablette . carbone . fin de vie
   unité: gCO2e
 
 tablette . durée d'usage:
@@ -173,7 +181,11 @@ tablette . profil utilisation:
 
 ordinateur portable:
 ordinateur portable . construction:
-  formule: acv . ordinateur portable . carbone . fabrication + acv . ordinateur portable . carbone . distribution
+  formule: 
+    somme:
+      - acv . ordinateur portable . carbone . fabrication
+      - acv . ordinateur portable . carbone . distribution
+      - acv . ordinateur portable . carbone . fin de vie
   unité: gCO2e
 
 ordinateur portable . durée d'usage:
@@ -194,7 +206,11 @@ ordinateur portable . profil utilisation:
 
 TV:
 TV . construction:
-  formule: acv . TV . carbone . fabrication + acv . TV . carbone . distribution
+  formule:
+    somme:
+      - acv . TV . carbone . fabrication
+      - acv . TV . carbone . distribution
+      - acv . TV . carbone . fin de vie
   unité: gCO2e
 
 TV . durée d'usage:
@@ -215,12 +231,20 @@ TV . profil utilisation:
 
 ordinateur fixe:
 ordinateur fixe . construction:
-  formule: acv . ordinateur fixe . carbone . fabrication + acv . ordinateur fixe . carbone . distribution
+  formule:
+    somme:
+      - acv . ordinateur fixe . carbone . fabrication
+      - acv . ordinateur fixe . carbone . distribution
+      - acv . ordinateur fixe . carbone . fin de vie
   unité: gCO2e
 
 écran:
 écran . construction:
-  formule: acv . écran . carbone . fabrication + acv . écran . carbone . distribution
+  formule:
+    somme:
+      - acv . écran . carbone . fabrication
+      - acv . écran . carbone . distribution
+      - acv . écran . carbone . fin de vie
   unité: gCO2e
 
 ordinateur et écran:

--- a/rules/visio.publicodes
+++ b/rules/visio.publicodes
@@ -40,7 +40,7 @@ visio . qualité . facteur qualité:
         alors: 3
       - si: qualité = 'ultra HD'
         alors: 7
-  unité: Go/heure
+  unité: Go/h
 
 visio . durée:
   titre: Temps de visionnage
@@ -49,8 +49,8 @@ visio . durée:
   unité: minute
 
 visio . durée en heure:
-  formule: durée / 60
-  unité: heure
+  formule: durée / 60 minute/h
+  unité: h
 
 visio . taille:
   titre: Taille de la vidéo
@@ -160,7 +160,7 @@ visio . data center:
 visio . data center . construction:
   valeur: construction data center
   contexte:
-    construction data center . serveur . facteur d'allocation: facteur allocation serveur
+    construction data center . serveur . facteur d'allocation: facteur allocation serveur * visio . durée en heure
   note: |
     Stockage négligé car pas d'enregistrement considéré.
     Ici, sont reprises les données issues des études sur le streaming.
@@ -176,10 +176,10 @@ visio . data center . usage:
   unité: gCO2e
 
 visio . data center . usage . consommation électricité:
-  formule: taille * électricité par Go / 1000
+  formule: taille * électricité par Go / 1000 Wh/kWh
   unité: kWh
 
 visio . data center . usage . électricité par Go:
-  formule: streaming . data center . usage . électricité par Go
+  formule: streaming . data center . usage . électricité par Go * 1000000 Wh/MWh
   unité: Wh/Go
   note: chiffre issu du streaming ici


### PR DESCRIPTION
- [x] La construction dans le modèle NO sous entend plusieurs étapes de l'ACV (et pas seulement la construction comme on a dans les nouvelles données). Donc là, la règle construction que tu as remplacée est celle prise pour la valeur de fabrication qui correspond à : construction + distribution (+ fin de vie ? -> à confirmer)
- [x] L'usage est calculé via publicodes dans le modèle NO et là on ajoute une valeur dans le dur pour l'usage or il faudrait voir comment retrouver la valeur transmise par Julia dans la colonne usage via le modèle publicodes directement (à avoir en tête notamment que le FE du mix utilisé par Julia est celui de 2021 et pas 2022, les durée de vie sont différentes, méthode également à priori). -> cf calcul de la construction réelle, l'usage calculé par Julia correspondant à l'impact de la conso électrique de l'appareil sur toute sa durée de vie
- [x] On aimerait à terme importer depuis ce modèle les FE des terminaux dans NGC, il faudrait donc le compléter (même si ce n'est pas utilisé directement dans ce modèle) par les terminaux de NGC (et ICO2 !), pour qu'on puisse importer les données directement dans des modèles publicodes externes. Un mail a été envoyé à Julia pour récupérer les FE davantage d'appareils